### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,23 +12,23 @@ SMARTWAV	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-reset                KEYWORD2
-sleep                KEYWORD2
-getStatus            KEYWORD2
-playTracks           KEYWORD2
-pausePlay            KEYWORD2
-rewindTrack          KEYWORD2
-nextTrack            KEYWORD2
-playTrackName        KEYWORD2
-stopTrack            KEYWORD2
-continuousPlay       KEYWORD2
-volume               KEYWORD2
-setFolder            KEYWORD2
-getFileName          KEYWORD2
-getFolderName        KEYWORD2
-getFileList          KEYWORD2
-getFolderList        KEYWORD2
-playSpeed            KEYWORD2
+reset	KEYWORD2
+sleep	KEYWORD2
+getStatus	KEYWORD2
+playTracks	KEYWORD2
+pausePlay	KEYWORD2
+rewindTrack	KEYWORD2
+nextTrack	KEYWORD2
+playTrackName	KEYWORD2
+stopTrack	KEYWORD2
+continuousPlay	KEYWORD2
+volume	KEYWORD2
+setFolder	KEYWORD2
+getFileName	KEYWORD2
+getFolderName	KEYWORD2
+getFileList	KEYWORD2
+getFolderList	KEYWORD2
+playSpeed	KEYWORD2
 
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords